### PR TITLE
BAH-3163 | Add. node:20-alphine As Docker Base Image

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -5,8 +5,8 @@ RUN npm install
 RUN npm run build
 
 # stage: 2 ?~@~T the production environment
-FROM node:18.15.0-alpine
-RUN npm install -g serve@13.0.4
+FROM node:20-alpine
+RUN npm install -g serve@14.2.0
 COPY --from=build-deps /app/dist/ dist/
 EXPOSE 5000
 


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

**Base Image Update**: The base image `node` has been upgraded from version `18.15.0-alpine` to version `20-alpine`. 
**Package Version Update**: The package `serve` has been upgraded from version `13.0.4` to version `14.2.0`.