### PR TITLE
BAH-4100 | Fix. Show timestamp for expired consent requests as well

### DIFF
--- a/src/components/ConsentsListTable/ConsentsListTable.js
+++ b/src/components/ConsentsListTable/ConsentsListTable.js
@@ -57,6 +57,10 @@ const ConsentsListTable = ({ loadConsents, consentsList, loading }) => {
     return status.toUpperCase() == 'GRANTED';
   }
 
+  function showConsentTimeStamp(status) {
+    return isGranted(status) || status.toUpperCase() == 'EXPIRED';
+  }
+
   function getPatientFullName(patient) {
     return `${patient.firstName} ${patient.lastName}`;
   }
@@ -103,10 +107,10 @@ const ConsentsListTable = ({ loadConsents, consentsList, loading }) => {
             name: getPatientFullName(consent.patient),
             id: consent.patient.id,
             status: getStatusText(consent.status),
-            grantedOn: isGranted(consent.status)
+            grantedOn: showConsentTimeStamp(consent.status)
               ? formatDateString(consent.approvedDate, true)
               : '-',
-            expiredOn: isGranted(consent.status)
+            expiredOn: showConsentTimeStamp(consent.status)
               ? formatDateString(consent.expiredDate, true)
               : '-',
             createdOn: formatDateString(consent.createdDate, true),


### PR DESCRIPTION
This PR enhances the Consent List page to show the timestamp information for expired consent requests

Before:
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/002237b0-6a9d-405f-a2a1-64a2757056b4">

After:
<img width="1238" alt="Screenshot 2024-09-03 at 10 10 31 PM" src="https://github.com/user-attachments/assets/f8bcefaa-32d2-4bb8-9047-c2147859ae7f">
